### PR TITLE
Cambio de palabra solicitante por dependencia

### DIFF
--- a/application/views/reserva.php
+++ b/application/views/reserva.php
@@ -32,7 +32,7 @@
 	    	<fieldset class="contenedorSolicitate">
 	    	<legend class="contenedorSolicitate">Solicitante</legend>
 
-	    		<label>Solicitante:</label> <input type="text" class="form-control" id="solicitante"/>
+	    		<label>Depenencia:</label> <input type="text" class="form-control" id="solicitante"/>
 				
 				
 				<br>


### PR DESCRIPTION
Esto es por pedido del cliente ya que nos a manifestado cambiar palabras claves por llamarlo de alguna manera a la interfaz del proyecto,  cambio de nombre de solicitante por dependencia, puesto que la dependencia es la que solicita el préstamo.
